### PR TITLE
fix Content-Type in POST request

### DIFF
--- a/graph-sample/app/helpers/graph_helper.rb
+++ b/graph-sample/app/helpers/graph_helper.rb
@@ -21,7 +21,7 @@ module GraphHelper
                    headers: headervals,
                    query: params
     when 'POST'
-      headers['Content-Type'] = 'application/json'
+      headervals['Content-Type'] = 'application/json'
       HTTParty.post "#{GRAPH_HOST}#{endpoint}",
                     headers: headervals,
                     query: params,


### PR DESCRIPTION
POST requests to create an event failed with an error `UnableToDeserializePostBody` this commit fixes the header content type of the post request

closes #48