### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ page_type: sample
 description: This sample demonstrates how to use the Microsoft Graph .NET SDK to access data in Office 365 from Ruby on Rails apps.
 products:
 - ms-graph
-- microsoft-graph-calendar-api
 - office-exchange-online
 languages:
 - ruby


### PR DESCRIPTION
`microsoft-graph-calendar-api` taxonomy slug has been deprecated. `ms-graph` is now the accepted value. 